### PR TITLE
Make South Africa API URL configurable

### DIFF
--- a/kingfisher_scrapy/settings.py
+++ b/kingfisher_scrapy/settings.py
@@ -117,6 +117,8 @@ KINGFISHER_PARAGUAY_HACIENDA_CLIENT_SECRET = os.getenv('KINGFISHER_PARAGUAY_HACI
 # To get an API account, visit https://www.contrataciones.gov.py/datos/adm/signup
 KINGFISHER_PARAGUAY_DNCP_REQUEST_TOKEN = os.getenv('KINGFISHER_PARAGUAY_DNCP_REQUEST_TOKEN')
 
+KINGFISHER_ZA_NT_API_URL = os.getenv('KINGFISHER_ZA_NT_API_URL', 'https://ocds-api.etenders.gov.za/api/OCDSReleases')
+
 # To get an API account, contact contact@openopps.com.
 KINGFISHER_OPENOPPS_USERNAME = os.getenv('KINGFISHER_OPENOPPS_USERNAME')
 KINGFISHER_OPENOPPS_PASSWORD = os.getenv('KINGFISHER_OPENOPPS_PASSWORD')

--- a/kingfisher_scrapy/spiders/south_africa_national_treasury_api.py
+++ b/kingfisher_scrapy/spiders/south_africa_national_treasury_api.py
@@ -29,6 +29,14 @@ class SouthAfricaNationalTreasuryAPI(LinksSpider):
     # LinksSpider
     formatter = staticmethod(parameters('PageNumber'))
 
+    @classmethod
+    def from_crawler(cls, crawler, *args, **kwargs):
+        spider = super(SouthAfricaNationalTreasuryAPI, cls).from_crawler(crawler, *args, **kwargs)
+
+        spider.base_url = crawler.settings.get('KINGFISHER_ZA_NT_API_URL')
+
+        return spider
+
     def start_requests(self):
-        yield scrapy.Request('https://ocds-api.etenders.gov.za/api/OCDSReleases?PageNumber=1&PageSize=50&'
+        yield scrapy.Request(f'{self.base_url}?PageNumber=1&PageSize=50&'
                              f'dateFrom={self.from_date}&dateTo={self.until_date}', meta={'file_name': 'start.json'})


### PR DESCRIPTION
Currently https://data.etenders.gov.za/ points to https://ocds-api-ocds-dev.azurewebsites.net/swagger/index.html

The data at the default and this alternative endpoint appears to match, but since I'm reusing this in https://github.com/vulekamali/ocds-data-summary it's nice for it to be easy to configure.